### PR TITLE
支持内嵌代码块

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,3 +41,5 @@ nav:
     - '开源模型与本地化': '03-Tooling/01-local-deployment.md'
   - '贡献指南': '04-Contributing/README.md'
   - '附录': '05-Appendix/README.md'
+markdown_extensions:
+  - pymdownx.superfences


### PR DESCRIPTION
[Fenced Code Blocks are only supported at the document root level.](https://python-markdown.github.io/extensions/fenced_code_blocks/#syntax:~:text=Fenced%20Code%20Blocks%20are%20only%20supported%20at%20the%20document%20root%20level) 导致所有内嵌代码块渲染异常。

根据官方文档建议引入 [SuperFences](https://facelessuser.github.io/pymdown-extensions/extensions/superfences/)。